### PR TITLE
Update info.json

### DIFF
--- a/xp-for-buildings/info.json
+++ b/xp-for-buildings/info.json
@@ -21,7 +21,7 @@
     "? 248k",
     "? warptorio2",
     "? space-exploration-postprocess",
-    "! Factory Levels"
+    "! factory-levels"
     
   ]
 }


### PR DESCRIPTION
Correctly name the factory levels mod.  (The mod portal's dependency viewer listed this as invalid, and the actual mod didn't list this mod either in its other mods referenced tab.)